### PR TITLE
Bugfix: Links from HTML-Source weren't added to target items

### DIFF
--- a/src/scripts/jquery.taxonomyBrowser.js
+++ b/src/scripts/jquery.taxonomyBrowser.js
@@ -151,7 +151,8 @@
                   label: label,
                   id: id,
                   slug: id,
-                  parent: parent                  
+                  parent: parent,
+                  url: $child.attr('href') || '#'
                 });
 
 


### PR DESCRIPTION
Links in children li > a weren't added to final structure, so you can't set links
